### PR TITLE
Identified part/pin rotation values.

### DIFF
--- a/Layer render/part_data_parser.js
+++ b/Layer render/part_data_parser.js
@@ -48,6 +48,7 @@ class PartDataParser {
       part_size: this.dataView.getUint32(this.offset, true),
       part_x: 0,
       part_y: 0,
+	  part_rotation:0,
       visibility: 0,
       part_group_name_size: 0,
       part_group_name: ''
@@ -63,7 +64,8 @@ class PartDataParser {
     header.part_y = this.dataView.getUint32(this.offset, true);
     this.offset += 4;
 
-    // Skip padding 0x10-0x13
+    // Read part rotation value
+	header.part_rotation = this.dataView.getUint32(this.offset,true);
     this.offset += 4;
 
     header.visibility = this.dataView.getUint8(this.offset);
@@ -250,7 +252,7 @@ class PartDataParser {
     const un2 = this.dataView.getUint32(this.offset, true);
     this.offset += 4;
 
-    const un3 = this.dataView.getUint32(this.offset, true);
+    const pinRotation = this.dataView.getUint32(this.offset, true);
     this.offset += 4;
 
     const pinNameSize = this.dataView.getUint32(this.offset, true);
@@ -292,7 +294,7 @@ class PartDataParser {
       x,
       y,
       un2,
-      un3,
+      pin_rotation: pinRotation,
       pin_name_size: pinNameSize,
       pin_name: pinName,
       height,

--- a/XZZPCB Decrypted.hexpat
+++ b/XZZPCB Decrypted.hexpat
@@ -186,7 +186,7 @@ struct part_sub_type_09 {
     u32 pin_x;
     u32 pin_y;
     padding[4];
-    padding[4];
+    u32 pin_rotation;
     u32 pin_name_size;
     char pin_name[pin_name_size];
     
@@ -209,7 +209,7 @@ struct type_07 {
     padding[4];
     u32 part_x;
     u32 part_y;
-    padding[4]; // scale maybe
+    u32 part_rotation;
     u8 flag1; // all 1
     u8 flag2; // all 0
     u32 pad_size_length;


### PR DESCRIPTION
These rotation values are needed to properly render components and pins properly, with all pins/pads contained within part boundaries. Trying to render components and pins with just width and height values alone ends poorly.

I found these a few months back and figured they may come in handy if you weren't already aware of them. 